### PR TITLE
Fix missing overwrite option to avoid user prompt on existing files...

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -49,7 +49,7 @@ function import_osm_water_polygons() {
 function import_osm_simplified_water_polygons() {
     echo "Import simplified OpenStreetMap water polygons"
     wget -N https://osmdata.openstreetmap.de/download/simplified-water-polygons-split-3857.zip
-    unzip simplified-water-polygons-split-3857.zip
+    unzip -o simplified-water-polygons-split-3857.zip
     ogr2ogr \
         -progress \
         -f Postgresql \


### PR DESCRIPTION
Fix missing `-o` option to `unzip` in order to avoid some user prompts when overwriting existing files.

Fix https://github.com/baremaps/openstreetmap-vecto/issues/12