### PR TITLE
Change style to display building numbers (#6)

### DIFF
--- a/config/building/layer.yaml
+++ b/config/building/layer.yaml
@@ -7,9 +7,3 @@ queries:
       SELECT id, tags, geom 
       FROM osm_ways_z${zoom}
       WHERE tags ? 'building'
-  - minZoom: 13
-    maxZoom: 20
-    sql: |
-      SELECT id, tags, geom 
-      FROM osm_relations_z${zoom} 
-      WHERE tags ? 'building'

--- a/config/building/stylesheet.yaml
+++ b/config/building/stylesheet.yaml
@@ -9,3 +9,24 @@ styles:
       fill-color: rgb(216, 208, 201)
       fill-antialias: true
       fill-outline-color: rgb(199, 185, 174)
+
+  - id: building_number
+    layer: building
+    type: symbol
+    layout:
+      text-allow-overlap: false
+      text-anchor: center
+      text-field: "{addr:housenumber}"
+      text-font: ["Noto Sans Regular"]
+      text-offset: [0,0]
+      text-size: 
+        stops: [
+          [15,0],
+          [16, 11],
+          [20, 11]
+        ]
+      visibility: visible
+    paint:
+      text-color: rgb(96,96,96)
+      text-halo-color: rgba(255,255,255,0.8)
+      text-halo-width: 1.2  

--- a/config/points/stylesheet.yaml
+++ b/config/points/stylesheet.yaml
@@ -1,5 +1,25 @@
 id: points
 styles:
+  - id: building_number_node
+    layer: points
+    type: symbol
+    layout:
+      text-allow-overlap: false
+      text-anchor: center
+      text-field: "{addr:housenumber}"
+      text-font: ["Noto Sans Regular"]
+      text-offset: [0,0]
+      text-size: 
+        stops: [
+          [15,0],
+          [16, 11],
+          [20, 11]
+        ]
+      visibility: visible
+    paint:
+      text-color: rgb(96,96,96)
+      text-halo-color: rgba(255,255,255,0.8)
+      text-halo-width: 1.2   
   - id: natural_trunk
     layer: points
     type: circle


### PR DESCRIPTION
**Comments:** 
building numbers are in the layer BUILDING but also in POINTS.
(here for example: (https://www.openstreetmap.org/node/5062051696)

**Problems yet to fix:**
-couldn't find how to attribute different minzoom and maxzoom for the buildings and the number-attribute. I used stops in the text-size instead, but it's not very clean.
-some buildings numbers appears 2 or 3 times. (for ex: http://localhost:9000/compare/#18.0000/46.533824/6.648183)
It's because the building contains amenities, shops, ... also with building numbers. 
The problem might be solved once we add the symbols for the amenities/shops.
