### PR TITLE
Script to serve openapi

### DIFF
--- a/scripts/serve_openapi.sh
+++ b/scripts/serve_openapi.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+HOST=${POSTGRES_HOST}
+PORT=${POSTGRES_PORT}
+
+source scripts/setup_openapi.sh --source-only
+source scripts/wait_for_db.sh
+
+wait_for_db
+setup_openapi
+
+baremaps openapi \
+  --database "jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?user=${POSTGRES_USER}&password=${POSTGRES_PASSWORD}" \
+  --port $APP_PORT


### PR DESCRIPTION
With cli support landed in https://github.com/baremaps/baremaps/pull/287 and building branches on the way https://github.com/baremaps/openstreetmap-vecto/tree/wip-build-baremaps, this will make it easier to spawn openapi service with docker compose-up.

cc @RemiDesgrange