### PR TITLE
Display locality names

### DIFF
--- a/style.json
+++ b/style.json
@@ -916,6 +916,23 @@
       "text-halo-width" : 1.2
     }
   }, {
+    "id" : "locality_label",
+    "type" : "symbol",
+    "filter" : [ "all", [ "==", [ "get", "place" ], "locality" ], [ ">=", [ "zoom" ], 15 ], [ "<=", [ "zoom" ], 17 ] ],
+    "source" : "baremaps",
+    "source-layer" : "points",
+    "layout" : {
+      "visibility" : "visible",
+      "text-font" : [ "Noto Sans Regular" ],
+      "text-field" : [ "get", "name" ],
+      "text-size" : [ "interpolate", [ "exponential", 1.2 ], [ "zoom" ], 15, 9.5, 18, 13 ]
+    },
+    "paint" : {
+      "text-color" : [ "interpolate", [ "exponential", 2.2 ], [ "zoom" ], 15, "rgba(0, 0, 0, 1)", 16.5, "rgba(105, 105, 105, 1)" ],
+      "text-halo-color" : "rgba(255, 255, 255, 0.8)",
+      "text-halo-width" : 2
+    }
+  }, {
     "id" : "neighbourhood_label",
     "type" : "symbol",
     "filter" : [ "all", [ "==", [ "get", "place" ], "neighbourhood" ] ],
@@ -976,7 +993,7 @@
       "visibility" : "visible",
       "text-font" : [ "Noto Sans Regular" ],
       "text-field" : [ "get", "name" ],
-      "text-size" : [ "interpolate", [ "exponential", 1.2 ], [ "zoom" ], 11, 8, 13, 12, 14, 13 ]
+      "text-size" : [ "interpolate", [ "exponential", 1.2 ], [ "zoom" ], 11, 9, 13, 12, 14, 13 ]
     },
     "paint" : {
       "text-color" : [ "interpolate", [ "exponential", 2.2 ], [ "zoom" ], 11, "rgba(0, 0, 0, 1)", 13, "rgba(105, 105, 105, 1)" ],

--- a/tileset.json
+++ b/tileset.json
@@ -28,31 +28,38 @@
           "minzoom": 4,
           "maxzoom": 8,
           "sql": "SELECT id, tags, geom FROM osm_nodes WHERE tags != '{}' AND tags ->> 'place' IN ('country', 'city', 'sea', 'state', 'county')"
-        },{
+        },
+        {
           "minzoom": 8,
           "maxzoom": 11,
           "sql": "SELECT id, tags, geom FROM osm_nodes WHERE tags != '{}' AND tags ->> 'place' IN ('country', 'state', 'region', 'province', 'district', 'county', 'municipality', 'city', 'town')"
-        },{
+        },
+        {
           "minzoom": 11,
           "maxzoom": 12,
           "sql": "SELECT id, tags, geom FROM osm_nodes WHERE tags != '{}' AND tags ->> 'place' IN ('country', 'state', 'region', 'province', 'district', 'county', 'municipality', 'city', 'town', 'village')"
-        },{
+        },
+        {
           "minzoom": 12,
           "maxzoom": 13,
           "sql": "SELECT id, tags, geom FROM osm_nodes WHERE tags != '{}' AND tags ->> 'place' IN ('region', 'province', 'district', 'county', 'municipality', 'city', 'town', 'village')"
-        },{
+        },
+        {
           "minzoom": 13,
           "maxzoom": 14,
           "sql": "SELECT id, tags, geom FROM osm_nodes WHERE tags != '{}' AND tags ->> 'place' IN ('region', 'province', 'district', 'county', 'municipality', 'city', 'town', 'village', 'quarter', 'hamlet')"
-        },{
+        },
+        {
           "minzoom": 14,
           "maxzoom": 15,
           "sql": "SELECT id, tags, geom FROM osm_nodes WHERE tags != '{}' AND tags ->> 'place' IN ('village', 'quarter', 'hamlet', 'neighborhood')"
-        },{
+        },
+        {
           "minzoom": 15,
           "maxzoom": 16,
           "sql": "SELECT id, tags, geom FROM osm_nodes WHERE tags != '{}' AND tags ->> 'place' IN ('hamlet', 'neighborhood')"
-        },{
+        },
+        {
           "minzoom": 16,
           "maxzoom": 18,
           "sql": "SELECT id, tags, geom FROM osm_nodes WHERE tags != '{}' AND tags ->> 'place' IN ('neighborhood')"
@@ -60,7 +67,7 @@
         {
           "minzoom": 10,
           "maxzoom": 14,
-          "sql": "SELECT id, tags, geom FROM osm_nodes WHERE tags != '{}' AND tags ->> 'natural' IN ('peak', 'volcano')"
+          "sql": "SELECT id, tags, geom FROM osm_nodes WHERE tags != '{}' AND (tags ->> 'natural' IN ('peak', 'volcano')) OR (tags ->> 'highway' IN ('motorway_junction'))"
         },
         {
           "minzoom": 12,


### PR DESCRIPTION
I want to display the localities at 15-18 zoom levels, but I noticed that if I put 18, they are displayed -> 19, so I decided to put 17 and it works. That doesn't concern 15 value.

In the tileset, if I add _locality_ to 15-18 zoom levels and I delete the 14-20 general tile for points (just to check), localities aren't displayed. With other _place_ values it's in order.

I used this PR (to avoid one exclusively for that) to add some missing linebreak in the tileset and add something I forgot for the displaying of motorway_junction.