### PR TITLE
Add "tools" section in README and fix screenshot.png

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Simply put, it adds in the ability to describe the `vector_tiles` and their cont
 The configuration format used in the `style.json` follows the [Mapbox style specification](https://github.com/mapbox/mapbox-gl-js).
 Baremaps integrates [Maputnik](https://maputnik.github.io/) and most of the modifications will take place in the browser.
 
+## Tools
+
+* [Overpass turbo](https://overpass-turbo.eu/) from [taginfo](https://taginfo.openstreetmap.org/)
+
 ## Contributing
 
 As a lot remains to be done, contributions and feedbacks are welcome. 


### PR DESCRIPTION
Are the informations about the overpass turbo tool sufficient with the links ?

The screenshot.png is broken, I took another one in Maputnik and did a little modification in Photoshop to make the zoom buttons invisible, that shows the actual progression and it's maybe a good thing ?