### PR TITLE
Remove natural_water from "natural" layer

### DIFF
--- a/style.json
+++ b/style.json
@@ -110,7 +110,7 @@
       "visibility" : "visible"
     },
     "paint" : {
-      "fill-color" : [ "match", [ "get", "natural" ], "glacier", "rgb(221, 236, 236)", "wood", "rgb(157, 202, 138)", "scrub", "rgb(201, 216, 173)", "heath", "rgb(214, 217, 159)", "grassland", "rgb(207, 236, 177)", "bare_rock", "rgb(217, 212, 206)", "scree", "rgb(232, 223, 216)", "shingle", "rgb(232, 223, 216)", "sand", "rgb(240, 229, 196)", "water", "rgb(170, 211, 223)", "rgba(0, 0, 0,0)" ],
+      "fill-color" : [ "match", [ "get", "natural" ], "glacier", "rgb(221, 236, 236)", "wood", "rgb(157, 202, 138)", "scrub", "rgb(201, 216, 173)", "heath", "rgb(214, 217, 159)", "grassland", "rgb(207, 236, 177)", "bare_rock", "rgb(217, 212, 206)", "scree", "rgb(232, 223, 216)", "shingle", "rgb(232, 223, 216)", "sand", "rgb(240, 229, 196)", "rgba(0, 0, 0,0)" ],
       "fill-antialias" : true
     }
   }, {


### PR DESCRIPTION
Natural_water was in _natural_ layer and in _natural_overlay_ layer. It must be over natural_wood which is in _natural_ layer, so we only should keep it in _natural_overlay_ layer.